### PR TITLE
Edited ADC.cpp example and common Makefile for Navio2

### DIFF
--- a/C++/Examples/ADC/ADC.cpp
+++ b/C++/Examples/ADC/ADC.cpp
@@ -1,42 +1,26 @@
-/*
-Provided to you by Emlid Ltd (c) 2014.
-twitter.com/emlidtech || www.emlid.com || info@emlid.com
-
-Example: Control ADS1115 connected to PCA9685 driver onboard of Navio shield for Rapspberry Pi.
-
-Connect a wire to P1 and the ADC will measure its voltage and display it.
-Be careful, do not connect high-voltage circuits, for acceptable range check the datasheet for ADS1115.
-
-To run this example navigate to the directory containing it and run following commands:
-make
-./ADC
-*/
-
 #include <unistd.h>
-#include <err.h>
-#include <cstdint>
 #include <cstdio>
-
 #include <Navio/Util.h>
+#include <Navio/ADC.h>
 
-int main() {
-
-    const char *channel_path = "/sys/kernel/rcio/adc/ch0";
+int main(int argc, char *argv[])
+{
+    ADC adc{};
+    adc.init();
+    float results[adc.get_channel_count()] = {0.0f};
 
     if (check_apm()) {
         return 1;
     }
 
     while (true) {
-        uint32_t conversion;
-
-        if (read_file(channel_path, "%u", &conversion) < 0) {
-            warn("Unable to get voltage");
+        for (int i = 0; i < ARRAY_SIZE(results); i++){
+            results[i] = adc.read(i);
+            printf("A%d: %.4fV ", i, results[i] / 1000);
         }
-
-        printf("%.4fV ", static_cast<float> (conversion / 1000.0f));
-
         printf("\n");
+        
+        usleep(500000);
     }
 
     return 0;

--- a/C++/Examples/ADC/Makefile
+++ b/C++/Examples/ADC/Makefile
@@ -3,7 +3,7 @@ NAVIO = ../../Navio
 INCLUDES = -I ../..
 
 all:
-	$(CXX) -std=gnu++11 $(INCLUDES) ADC.cpp $(NAVIO)/Util.cpp -o ADC
+	$(CXX) -std=gnu++11 $(INCLUDES) ADC.cpp $(NAVIO)/Util.cpp $(NAVIO)/ADC.cpp -o ADC
 
 clean:
 	rm ADC

--- a/C++/Examples/Makefile
+++ b/C++/Examples/Makefile
@@ -1,4 +1,4 @@
-MODULES = AccelGyroMag ADC AHRS Barometer LED2 Servo RCInput
+MODULES = AccelGyroMag ADC AHRS Barometer GPS LED2 Servo RCInput
 
 all:
 	for dir in $(MODULES); do \

--- a/C++/Navio/ADC.cpp
+++ b/C++/Navio/ADC.cpp
@@ -1,0 +1,60 @@
+#include <cstdio>
+#include <unistd.h>
+#include <fcntl.h>
+#include <cstdlib>
+#include <err.h>
+
+#include "ADC.h"
+#include "Util.h"
+
+#define ADC_SYSFS_PATH "/sys/kernel/rcio/adc"
+
+ADC::ADC()
+{
+
+}
+
+ADC::~ADC()
+{
+}
+
+void ADC::init()
+{
+    for (size_t i = 0; i < ARRAY_SIZE(channels); i++) {
+        channels[i] = open_channel(i);
+        if (channels[i] < 0) {
+            perror("open");
+        }
+    }
+}
+
+int ADC::get_channel_count(void)
+{
+    return CHANNEL_COUNT;
+}
+
+int ADC::read(int ch)
+{
+    char buffer[10];
+
+    if (::pread(channels[ch], buffer, ARRAY_SIZE(buffer), 0) < 0) {
+        perror("pread");
+    }
+
+    return atoi(buffer);
+}
+
+int ADC::open_channel(int channel)
+{
+    char *channel_path;
+    if (asprintf(&channel_path, "%s/ch%d", ADC_SYSFS_PATH, channel) == -1) {
+        err(1, "adc channel: %d\n", channel);
+    }
+
+    int fd = ::open(channel_path, O_RDONLY);
+
+    free(channel_path);
+
+    return fd;
+}
+

--- a/C++/Navio/ADC.h
+++ b/C++/Navio/ADC.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstddef>
+
+class ADC 
+{
+public:
+    void init();
+    int read(int ch); 
+    int get_channel_count(void);
+    ADC();
+    ~ADC();
+
+private:
+    int open_channel(int ch);
+
+    static const size_t CHANNEL_COUNT = 5;
+    int channels[CHANNEL_COUNT];
+};

--- a/C++/Navio/Ublox.cpp
+++ b/C++/Navio/Ublox.cpp
@@ -163,7 +163,7 @@ int UBXParser::decodeMessage(std::vector<double>& data)
 
     // Count the checksum
 
-    for (int i=2;i<(length-2);i++){
+    for (unsigned int i=2;i<(length-2);i++){
         CK_A += *(message+pos+i);
         CK_B += CK_A;
     }
@@ -256,7 +256,7 @@ int UBXParser::checkMessage()
 
     // Count the checksum
 
-    for (int i=2;i<(length-2);i++){
+    for (unsigned int i=2;i<(length-2);i++){
         CK_A += *(message+pos+i);
         CK_B += CK_A;
     }


### PR DESCRIPTION
Reworked C++ ADC example. Now it measures all available channels.
Added GPS example directory to modules list in C++/Examples/Makefile.
