### PR TITLE
Fixed number of channels in python ADC example

### DIFF
--- a/Python/navio/adc.py
+++ b/Python/navio/adc.py
@@ -1,5 +1,5 @@
 class ADC():
-    channel_count = 5
+    channel_count = 6
     channels = []
 
     def __init__(self):


### PR DESCRIPTION
adc.py module for ADC example had wrong value of channel_count variable.
