### PR TITLE
Python example - Fixes #28

### DIFF
--- a/Python/navio/pwm.py
+++ b/Python/navio/pwm.py
@@ -20,6 +20,7 @@ class PWM():
 
     def deinitialize(self):
         if self.is_enabled:
+            self.set_period(1)
             self.disable()
         with open(self.SYSFS_PWM_UNEXPORT_PATH, "a") as pwm_unexport:
             pwm_unexport.write(str(self.channel))


### PR DESCRIPTION
After pwm-channel deinitialization some configurations seems to linger.
This causes pwm outputs to potentially get an unexpected behaviour.

By simply setting period to 1, the pwm output will behave as default
after deinitialization.