### PR TITLE
Fix the use of 'lsm' as the default sensor

### DIFF
--- a/C++/Examples/AHRS/AHRS.cpp
+++ b/C++/Examples/AHRS/AHRS.cpp
@@ -399,8 +399,7 @@ std::string get_sensor_name(int argc, char *argv[])
 
         while ((parameter = getopt(argc, argv, "i:h")) != -1) {
             switch (parameter) {
-            case 'i': if (!strcmp(optarg,"mpu") ) return "mpu";
-                            else return "lsm";
+            case 'i': return optarg;
             case 'h': print_help(); return "";
             case '?': printf("Wrong parameter.\n");
                       print_help();

--- a/C++/Examples/AccelGyroMag/AccelGyroMag.cpp
+++ b/C++/Examples/AccelGyroMag/AccelGyroMag.cpp
@@ -63,8 +63,7 @@ std::string get_sensor_name(int argc, char *argv[])
 
         while ((parameter = getopt(argc, argv, "i:h")) != -1) {
             switch (parameter) {
-            case 'i': if (!strcmp(optarg,"mpu") ) return "mpu";
-                            else return "lsm";
+            case 'i': return optarg;
             case 'h': print_help(); return "-1";
             case '?': printf("Wrong parameter.\n");
                       print_help();


### PR DESCRIPTION
Return *optarg* as it is and validate name of the sensor in another function.
We have *get_inertial_sensor* method to check the name of the sensor