### PR TITLE
C++: change compiler variables to simplify cross-compilation

### DIFF
--- a/C++/Examples/FRAM/Makefile
+++ b/C++/Examples/FRAM/Makefile
@@ -1,10 +1,10 @@
-CC = g++
+CXX ?= g++
 NAVIO = ../../Navio
 INCLUDES = -I ../../Navio
 
 all:
 	$(MAKE) -C ../../Navio all
-	$(CC) $(INCLUDES) FRAM.cpp -L$(NAVIO) -lnavio -o FRAM
+	$(CXX) $(INCLUDES) FRAM.cpp -L$(NAVIO) -lnavio -o FRAM
 
 clean:
 	rm -f FRAM

--- a/C++/Examples/Multithread/Makefile
+++ b/C++/Examples/Multithread/Makefile
@@ -1,10 +1,10 @@
-CC = g++
+CXX ?= g++
 NAVIO = ../../Navio
 INCLUDES = -I ../../Navio
 
 all:
 	$(MAKE) -C ../../Navio all
-	$(CC) $(INCLUDES) threaded_baro.cpp -L$(NAVIO) -lnavio -lpthread -o threaded_baro
+	$(CXX) $(INCLUDES) threaded_baro.cpp -L$(NAVIO) -lnavio -lpthread -o threaded_baro
 
 clean:
 	rm threaded_baro

--- a/C++/Navio/Makefile
+++ b/C++/Navio/Makefile
@@ -1,4 +1,4 @@
-CXX = g++
+CXX ?= g++
 CFLAGS = -std=c++11 -Wno-psabi -c -I .
 
 SRC=$(wildcard */*.cpp)


### PR DESCRIPTION
Hello!

I tried to cross-compiled and got some errors: `ld returned 1 exit status`, `make: Command not found`, or just compiled using g++, not cross-compiler.

In order to fix this I suggest this change. 

Even though it doesn't fix everything (there's still dependency on pigpio library that can't just be installed on host machine), it's better.

After applying this change and compiling with `arm-linux-gnueabihf-g++` you'll get errors with RCInput_Navio.cpp that has a dependency on pigpio.h. I would try to handle with it in other commits. 
