### PR TITLE
C++: all: add pigpio library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "C++/Navio/pigpio"]
+	path = C++/Navio/pigpio
+	url = https://github.com/joan2937/pigpio.git

--- a/C++/Examples/RCInput/Makefile
+++ b/C++/Examples/RCInput/Makefile
@@ -1,7 +1,7 @@
 CXX ?= g++
 NAVIO = ../../Navio
 
-PIGPIO_PATH := $(PIGPIO_PATH)
+PIGPIO_PATH ?= $(NAVIO)/pigpio
 
 LIB = -L$(PIGPIO_PATH)
 
@@ -9,7 +9,7 @@ INCLUDES = -I ../../Navio -I$(PIGPIO_PATH)
 
 all:
 	$(MAKE) -C ../../Navio all
-	$(CXX) -std=gnu++11 $(INCLUDES) $(LIB) RCInput.cpp -L$(NAVIO) -lnavio -o RCInput -lrt -lpthread -lpigpio || $(MAKE) pigpio
+	$(CXX) -std=gnu++11 $(INCLUDES) $(LIB) RCInput.cpp -L$(NAVIO) -lnavio -o RCInput -lrt -lpthread -lpigpio
 
 clean:
 	rm -f RCInput

--- a/C++/Navio/Makefile
+++ b/C++/Navio/Makefile
@@ -1,5 +1,6 @@
 CXX ?= g++
-CFLAGS = -std=c++11 -Wno-psabi -c -I .
+PIGPIO_PATH ?= pigpio
+CFLAGS = -std=c++11 -Wno-psabi -c -I . -I$(PIGPIO_PATH)
 
 SRC=$(wildcard */*.cpp)
 OBJECTS = $(SRC:.cpp=.o) 
@@ -7,8 +8,14 @@ OBJECTS = $(SRC:.cpp=.o)
 %.o: %.cpp
 	$(CXX) $(CFLAGS) -o $@ $< 
 
-all: $(OBJECTS)
+.PHONY: get_deps clean
+
+all: get_deps $(OBJECTS)
 	ar rcs libnavio.a $(OBJECTS)
+
+get_deps:
+	bash get_dependencies.sh
 
 clean:
 	rm -f */*.o *.a
+	$(MAKE) -C pigpio clean

--- a/C++/Navio/get_dependencies.sh
+++ b/C++/Navio/get_dependencies.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+ARCH=`dpkg --print-architecture`
+
+confirm_guard() {
+    echo "Would you like to install missing dependencies (requires sudo)? [y/n]"
+    while true; do
+        read answer
+        case $answer in
+            [Yy]* ) return ;;
+            [Nn]* ) exit ;;
+            * ) echo "Wrong answer" ;;
+        esac
+    done
+}
+
+if [[ "$ARCH" == *"arm"* ]]; then
+    if ! dpkg -s pigpio &> /dev/null; then
+        confirm_guard
+        sudo apt-get update
+        sudo apt-get install pigpio
+    fi
+else
+    git submodule update --init --recursive;
+    pushd pigpio;
+    make CROSS_PREFIX=arm-linux-gnueabihf-
+    popd;
+fi

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Collection of drivers and examples for Navio 2 - autopilot shield for Raspberry 
 
 Basic examples showing how to work with Navio's onboard devices using C++.
 
-* AccelGyroMag 
+* AccelGyroMag
 * ADC
 * AHRS
 * Barometer
@@ -44,7 +44,7 @@ Basic examples showing how to work with Navio's onboard devices using Python.
 * Servo
 
 
-### Utilities 
+### Utilities
 
 Applications and utilities for Navio.
 
@@ -52,9 +52,13 @@ Applications and utilities for Navio.
 * U-blox SPI to PTY bridge utility
 * U-blox SPI to TCP bridge utility
 
-### Problem with pigpio.h
+### Cross-compilation
 
-If you have got error: `fatal error: pigpio.h: No such file or directory`, install `pigpio` by commands:
+#### Requirements
 
-    sudo apt-get update
-    sudo apt-get install pigpio
+* Install the toolchain `gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf` (`sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf` for Debian based systems)
+
+#### Usage
+
+* `export CXX=arm-linux-gnueabihf-g++`
+* Compile the examples via `make`


### PR DESCRIPTION
Hello again!

When I tried to cross-compile, I have another issue (except #44): `fatal error: pigpio.h: No such file or directory`. The main problem is that pigpio library can't be just easily installed using apt-get to host machine.

I suggest this change to fix it. Now you can cross-compile simply using `export CXX=`. 

It is perfectly working as cross-compilation as native installation on RPi. 

Please, check it.