### PR TITLE
C++: Navio: Common: gpio: detect RPi version & gpio_base

### DIFF
--- a/C++/Navio/Common/gpio.cpp
+++ b/C++/Navio/Common/gpio.cpp
@@ -37,7 +37,7 @@ using namespace Navio;
 
 Pin::Pin(uint8_t pin):
     _pin(pin),
-    _gpio(NULL), 
+    _gpio(NULL),
     _mode(GpioModeInput)
 {
 }
@@ -49,7 +49,7 @@ Pin::~Pin()
     }
 }
 
-bool Pin::_deinit() 
+bool Pin::_deinit()
 {
     if (munmap(const_cast<uint32_t *>(_gpio), BLOCK_SIZE) < 0) {
         warnx("unmap failed");
@@ -92,9 +92,9 @@ bool Pin::init()
 
     /* No need to keep mem_fd open after mmap */
     if (close(mem_fd) < 0) {
-        warn("cannot close mem_fd");   
+        warn("cannot close mem_fd");
         return false;
-    } 
+    }
 
     _gpio = reinterpret_cast<volatile uint32_t *>(gpio_map); // Always use volatile pointer!
 

--- a/C++/Navio/Common/gpio.cpp
+++ b/C++/Navio/Common/gpio.cpp
@@ -16,9 +16,9 @@
 #define HIGH                1
 
 /* Raspberry Pi GPIO memory */
-#define BCM2708_PERI_BASE   0x20000000
-#define BCM2709_PERI_BASE   0x3F000000
-#define BCM2835_PERI_BASE   0x3F000000
+#define BCM2835_PERI_BASE   0x20000000
+#define BCM2837_PERI_BASE   0x3F000000
+#define BCM2711_PERI_BASE   0xFE000000
 #define GPIO_BASE(address)  (address + 0x200000)
 #define PAGE_SIZE           (4*1024)
 #define BLOCK_SIZE          (4*1024)
@@ -69,11 +69,11 @@ bool Pin::init()
     uint32_t address;
     int version = getRaspberryPiVersion();
     if (version == 1) {
-        address = GPIO_BASE(BCM2708_PERI_BASE);
-    } else if (version == 2) {
-        address = GPIO_BASE(BCM2709_PERI_BASE);
-    } else if (version == 3) {
         address = GPIO_BASE(BCM2835_PERI_BASE);
+    } else if (version == 2) {
+        address = GPIO_BASE(BCM2837_PERI_BASE);
+    } else if (version == 3) {
+        address = GPIO_BASE(BCM2837_PERI_BASE);
     }
 
     void *gpio_map = mmap(


### PR DESCRIPTION
Hello again! 

Recently I faced with problem with non-working LED example in C++ on Raspberry Pi 4. I found out that RPi 4 has another GPIO_BASE and was not defined in existed gpio.cpp (there were only three versions). It couldn't be simply defined because RPi version was detected using Hardware info but RPi 3 and 4 have the same hardware (BCM2835).

This is why I updated the mechanism of RPi version detection and gpio bases. 

After this change, you can be able to run C++ LED example on RPi 4 and it would work. 