### PR TITLE
Fix warnings during compilation

### DIFF
--- a/C++/Examples/AHRS.cpp
+++ b/C++/Examples/AHRS.cpp
@@ -411,6 +411,8 @@ std::string get_sensor_name(int argc, char *argv[])
 
         return "mpu";
     }
+
+    return std::string();
 }
 
 //============================== Main loop ====================================

--- a/C++/Examples/AccelGyroMag.cpp
+++ b/C++/Examples/AccelGyroMag.cpp
@@ -76,6 +76,7 @@ std::string get_sensor_name(int argc, char *argv[])
         return "mpu";
     }
 
+    return std::string();
 }
 //=============================================================================
 int main(int argc, char *argv[])


### PR DESCRIPTION
During building examples in Navio2/C++, regardless of cross-compilation or native build, some warnings appear:
```

Navio2/C++/Examples/AHRS.cpp: In function ‘std::string get_sensor_name(int, char**)’:
Navio2/C++/Examples/AHRS.cpp:414:1: warning: control reaches end of non-void function [-Wreturn-type]
      414 | }
          | ^
Navio2/C++/Examples/AccelGyroMag.cpp: In function ‘std::string get_sensor_name(int, char**)’:
Navio2/C++/Examples/AccelGyroMag.cpp:79:1: warning: control reaches end of non-void function [-Wreturn-type]
       79 | }
          | ^
```
It's needed to return string value in those functions even if control never reaches there. In the main function, if 'get_sensor_name' function returns an empty value, it will return EXIT_FAILURE which is why it is needed to return an empty string in case it's not Navio2.
