### PR TITLE
Replace xrange() with range() in LSM9DS1.c for Python 3 compatibility

### DIFF
--- a/Python/navio/lsm9ds1.py
+++ b/Python/navio/lsm9ds1.py
@@ -290,7 +290,7 @@ class LSM9DS1:
     def read_acc(self):
         # Read accelerometer
         response = self.readRegs(self.__DEVICE_ACC_GYRO, self.__LSM9DS1XG_OUT_X_L_XL, 6)
-        for i in xrange(3):
+        for i in range(0,3):
             self.accelerometer_data[i] = self.G_SI * (self.byte_to_float_le(response[2*i:2*i+2]) * self.acc_scale)
 
         self.accelerometer_data = [-self.accelerometer_data[1], -self.accelerometer_data[0], self.accelerometer_data[2]]
@@ -298,7 +298,7 @@ class LSM9DS1:
     def read_gyro(self):
         # Read gyroscope
         response = self.readRegs(self.__DEVICE_ACC_GYRO, self.__LSM9DS1XG_OUT_X_L_G, 6)
-        for i in xrange(3):
+        for i in range(0,3):
             self.gyroscope_data[i] = (self.PI / 180.0) * (self.byte_to_float_le(response[2*i:2*i+2]) * self.gyro_scale) 
 
         self.gyroscope_data = [-self.gyroscope_data[1], -self.gyroscope_data[0], self.gyroscope_data[2]]
@@ -306,7 +306,7 @@ class LSM9DS1:
     def read_mag(self):
         # Read magnetometer
         response = self.readRegs(self.__DEVICE_MAGNETOMETER, self.__LSM9DS1M_OUT_X_L_M, 6)
-        for i in xrange(3):
+        for i in range(0,3):
             self.magnetometer_data[i] = 100.0 * (self.byte_to_float_le(response[2*i:2*i+2]) * self.mag_scale)
 
         self.magnetometer_data[1] *=-1
@@ -324,17 +324,17 @@ class LSM9DS1:
 
         # Read accelerometer
         response = self.readRegs(self.__DEVICE_ACC_GYRO, self.__LSM9DS1XG_OUT_X_L_XL, 6)
-        for i in xrange(3):
+        for i in range(0,3):
             self.accelerometer_data[i] = self.G_SI * (self.byte_to_float_le(response[2*i:2*i+2]) * self.acc_scale)
 
         # Read gyroscope
         response = self.readRegs(self.__DEVICE_ACC_GYRO, self.__LSM9DS1XG_OUT_X_L_G, 6)
-        for i in xrange(3):
+        for i in range(0,3):
             self.gyroscope_data[i] = (self.PI / 180.0) * (self.byte_to_float_le(response[2*i:2*i+2]) * self.gyro_scale) 
 
         # Read magnetometer
         response = self.readRegs(self.__DEVICE_MAGNETOMETER, self.__LSM9DS1M_OUT_X_L_M, 6)
-        for i in xrange(3):
+        for i in range(0,3):
             self.magnetometer_data[i] = 100.0 * (self.byte_to_float_le(response[2*i:2*i+2]) * self.mag_scale)
 
         # Change rotation of LSM9DS1 like in MPU-9250


### PR DESCRIPTION
**Changes:**
- Replaced all occurrences of `xrange()` with `range()` in [`lsm9ds1.py`](diffhunk://#diff-b2cd0106deda77fe43deec9527d5f5aa89492bae5adb434af8bd7ed1ae8bd596L293-R309)

**Motivation:**

Python 3 removed `xrange()`, which causes compatibility issues. Since `range()` in Python 3 behaves similarly to `xrange()` in Python 2 (returning a lazy sequence), this change ensures that the code runs correctly in Python 3 without impacting functionality.